### PR TITLE
Split the version package.

### DIFF
--- a/README
+++ b/README
@@ -2,3 +2,11 @@ SailfishOS HW Adaptation droid
 
 Version metapackage.
 
+For each adaptation this package should be added as subpackage to the actual
+version package e.g. <device>-version and in the rpm/<device>-version.spec one
+should have:
+
+%include droid-hal-version/droid-hal-version.inc
+
+With the all device specific defines that are wanted.
+

--- a/droid-hal-version.inc
+++ b/droid-hal-version.inc
@@ -14,32 +14,68 @@
 %define _version_appendix (%{_target_cpu},%{_build_flavour})
 %endif
 
-Name:    droid-hal-version
+Name:    droid-hal-version-%{rpm_device}
 Version: 0.0.1
 Release: 1
 Summary: SailfishOS HW Adaptation droid version package %{version}.%{_obs_build_count} (%{_target_cpu},%{_build_flavour})
 Group:   System/Libraries
 License: BSD-3-Clause
 Source:  %{name}-%{version}.tar.gz
+
+# Generic dependencies
 BuildRequires: droid-hal
-BuildRequires: droid-hal-configs
-BuildRequires: gstreamer0.10-droidcamsrc
-BuildRequires: gstreamer0.10-omx
-BuildRequires: pkgconfig(libhardware)
+BuildRequires: droid-config
+BuildRequires: droid-config-sailfish
+BuildRequires: libhybris
 BuildRequires: mce-plugin-libhybris
-BuildRequires: ngfd-plugin-droid-vibrator
+
+%if 0%{?have_droid_bin:1}
+BuildRequires: droid-bin
+%endif
+
+# Kernel & Boot
+BuildRequires: droid-hal-kernel
+BuildRequires: droid-hal-img-boot
+BuildRequires: droid-hal-img-recovery
+BuildRequires: droid-config-preinit-plugins
+
+# Kernel modules
+%if 0%{?have_kernel_modules:1}
+BuildRequires: droid-hal-kernel-modules
+%endif
+
+# Audio
 BuildRequires: pulseaudio-modules-droid
+BuildRequires: droid-config-pulseaudio-settings
+
+# Camera
+%if 0%{?have_camera:1}
+BuildRequires: gstreamer0.10-droidcamsrc
+%endif
+
+# Multimedia
+%if 0%{?have_mm_omx:1}
+BuildRequires: gstreamer0.10-omx
+%endif
+
+# Haptics
+%if 0%{?have_vibrator:1}
+BuildRequires: ngfd-plugin-droid-vibrator
 BuildRequires: qt5-feedback-haptics-droid-vibrator
-BuildRequires: qt5-qpa-hwcomposer-plugin
-BuildRequires: qtscenegraph-adaptation
+%endif
+
+# Sensors
 BuildRequires: hybris-libsensorfw-qt5
 
+# Graphics
+BuildRequires: qt5-qpa-hwcomposer-plugin
+BuildRequires: qtscenegraph-adaptation
+
 %description
-SailfishOS HW Adaptation droid version/umbrella package (%{version}.%{_obs_build_count}) for %{_target_cpu} platform.
+SailfishOS HW Adaptation %{rpm_device} version/umbrella package (%{version}.%{_obs_build_count}) for %{_target_cpu} platform.
 
 %files
 %defattr(-,root,root,-)
-%config %{_sysconfdir}/droid-release
 %config %{_sysconfdir}/hw-release
 %{_datadir}/sailfish-version/packagelist.d/*
 
@@ -55,28 +91,26 @@ Group: System/Libraries
 %doc %{_datadir}/doc/SailfishOS/*
 
 %prep
-%setup -q
 
 %build
 
 %install
 echo "Building for %{_build_flavour}"
 mkdir -p %{buildroot}/%{_datadir}/sailfish-version/packagelist.d
-RPM_PATH=${RPM_SOURCE_DIR:-rpm}/${RPM_PACKAGE_NAME:-droid-hal-version}.spec
+RPM_PATH=rpm/droid-hal-version.spec
 for req in `rpmspec -q --buildrequires $RPM_PATH`; do
     rpm -qa $req >> %{buildroot}/%{_datadir}/sailfish-version/packagelist.d/%{name}
 done
 mkdir -p %{buildroot}/%{_sysconfdir}
 
-# Obtain DEVICE and VENDOR values from the info file provided by dhd
-. /usr/lib/droid-devel/device.info
-
 echo Creating hw-release
 # based on http://www.freedesktop.org/software/systemd/man/os-release.html
-cat > %{buildroot}/%{_sysconfdir}/droid-release <<EOF
+cat > %{buildroot}/%{_sysconfdir}/hw-release <<EOF
 # This file is copied as hw-release (analogous to os-release)
-MER_HA_DEVICE=$MER_HA_DEVICE
-MER_HA_VENDOR=$MER_HA_VENDOR
+NAME="%{vendor_pretty} %{device_pretty}"
+ID=%{rpm_device}
+MER_HA_DEVICE=%{rpm_device}
+MER_HA_VENDOR=%{rpm_vendor}
 VERSION="%{version}.%{_obs_build_count} %{_version_appendix}"
 VERSION_ID=%{version}.%{_obs_build_count}
 PRETTY_NAME="$DEVICE %{version}.%{_obs_build_count} %{_version_appendix}"
@@ -84,9 +118,9 @@ SAILFISH_BUILD=%{_obs_build_count}
 SAILFISH_FLAVOUR=%{_build_flavour}
 HOME_URL="https://sailfishos.org/"
 EOF
-cat %{buildroot}/%{_sysconfdir}/droid-release
+cat %{buildroot}/%{_sysconfdir}/hw-release
 
-ln -s %{_sysconfdir}/droid-release %{buildroot}/%{_sysconfdir}/hw-release
 mkdir -p %{buildroot}/%{_datadir}/doc/SailfishOS
-cp %{buildroot}/%{_datadir}/sailfish-version/packagelist.d/* %{buildroot}/%{_sysconfdir}/droid-release %{buildroot}/%{_datadir}/doc/SailfishOS/
+cp %{buildroot}/%{_datadir}/sailfish-version/packagelist.d/* %{buildroot}/%{_sysconfdir}/hw-release %{buildroot}/%{_datadir}/doc/SailfishOS/
 rpm -qa | sort > %{buildroot}/%{_datadir}/doc/SailfishOS/extended-packagelist-droid
+


### PR DESCRIPTION
Because every device eventually has their own release cycle we need to
split this and not have it common. We should however try to keep the
main things in this git tree and make it easily configurable for
different adaptation that have different types of hardware and packages.

Signed-off-by: Marko Saukko marko.saukko@jolla.com
