### PR TITLE
Prevent version in summary from getting too long.

### DIFF
--- a/droid-hal-version.inc
+++ b/droid-hal-version.inc
@@ -14,10 +14,12 @@
 %define _version_appendix (%{_target_cpu},%{_build_flavour})
 %endif
 
+%define _shortened_version %(echo %{version} | awk -F '+' '{print $1}')
+
 Name:    droid-hal-version-%{rpm_device}
 Version: 0.0.1
 Release: 1
-Summary: SailfishOS HW Adaptation droid version package %{version}.%{_obs_build_count} (%{_target_cpu},%{_build_flavour})
+Summary: SailfishOS HW Adaptation droid version package %{_shortened_version}.%{_obs_build_count} (%{_target_cpu},%{_build_flavour})
 Group:   System/Libraries
 License: BSD-3-Clause
 Source:  %{name}-%{version}.tar.gz


### PR DESCRIPTION
If a droid-hal-version-$DEVICE package is built on OBS and a service hook is used to pull the sources, and the source repository has no tags defined, the service hook generates a version string like  '0.0.1+master.20150731213455.d3b2370'.

This makes the summary field of the droid-hal-version package exceed the allowed field length.

This commit make sure everything after the + sign is stripped from the version before adding it to the summary field, preventing it to exceed the allowed length.

ps: I've never edited a specfile before, if there's a better way to do this, please let me know and I will fix this.
