### PR TITLE
dhv: Build require droid-hal-img packages only on OBS build.

### DIFF
--- a/droid-hal-version.inc
+++ b/droid-hal-version.inc
@@ -49,8 +49,10 @@ BuildRequires: droid-bin
 
 # Kernel & Boot
 BuildRequires: droid-hal-kernel
+%if 0%{?_obs_build_project:1}
 BuildRequires: droid-hal-img-boot
 BuildRequires: droid-hal-img-recovery
+%endif
 BuildRequires: droid-config-preinit-plugins
 
 # Kernel modules


### PR DESCRIPTION
[dhv] Build require droid-hal-img packages only on OBS build. JB#48042

Signed-off-by: Matti Kosola <matti.kosola@jolla.com>