### PR TITLE
droid-hal-version: Don't require qt5-feedback-haptics-native-vibrator

### DIFF
--- a/droid-hal-version.inc
+++ b/droid-hal-version.inc
@@ -77,7 +77,6 @@ BuildRequires: droid-config-pulseaudio-settings
 # Haptics native
 %if 0%{?have_vibrator_native:1} && 0%{!?have_vibrator:1} && 0%{!?have_ffmemless:1}
 BuildRequires: ngfd-plugin-native-vibrator
-BuildRequires: qt5-feedback-haptics-native-vibrator
 %endif
 
 # Haptics
@@ -86,10 +85,6 @@ BuildRequires: ngfd-plugin-droid-vibrator
 BuildRequires: qt5-feedback-haptics-droid-vibrator
 %endif
 
-# Haptics with ffmemless
-%if 0%{!?have_vibrator_native:1} && 0%{!?have_vibrator:1} && 0%{?have_ffmemless:1}
-BuildRequires: qt5-feedback-haptics-ffmemless
-%endif
 
 # Sensors
 %if 0%{!?native_build:1}


### PR DESCRIPTION
qt5-feedback-haptics-native-vibrator was replaced by libngf-qt5 in JB#55261.

[dhv] Don't BuildRequire qt5-feedback-haptics-native-vibrator. Fixes JB#56243

Signed-off-by: Björn Bidar <bjorn.bidar@jolla.com>