### PR TITLE
[dhv] Dont require pulseaudio-modules-droid on a native build

### DIFF
--- a/droid-hal-version.inc
+++ b/droid-hal-version.inc
@@ -75,7 +75,9 @@ BuildRequires: droid-hal-kernel-modules
 %endif
 
 # Audio
+%if 0%{!?native_build:1}
 BuildRequires: pulseaudio-modules-droid
+%endif
 BuildRequires: droid-config-pulseaudio-settings
 
 # Haptics native


### PR DESCRIPTION
An older PR to add the ability for native devices missed this as it used a hacked version of the pulseaudio module.  New builds use pulseaudio-modules-keepalive instead, which is built by Jolla and doesnt get built by ports.