### PR TITLE
droid-hal-version: fix /etc/hw-release symlink

### DIFF
--- a/droid-hal-version.inc
+++ b/droid-hal-version.inc
@@ -148,7 +148,7 @@ SAILFISH_FLAVOUR=%{_build_flavour}
 HOME_URL=%{home_url}
 EOF
 cat %{buildroot}/%{_prefix}/lib/hw-release
-ln -s %{_prefix}/lib/hw-release %{buildroot}/%{_sysconfdir}/hw-release
+ln -s ../%{_prefix}/lib/hw-release %{buildroot}/%{_sysconfdir}/hw-release
 
 mkdir -p %{buildroot}/%{_datadir}/doc/SailfishOS
 cp %{buildroot}/%{_sysconfdir}/hw-release %{buildroot}/%{_datadir}/doc/SailfishOS/


### PR DESCRIPTION
A relative symlink instead of an absolute symlink is necessary to avoid breaking the link in a chroot or initrd environment.

[droid-hal-version] Fix /etc/hw-release symlink.